### PR TITLE
feat(relay): persist MTConnect XML condition tag name as value

### DIFF
--- a/services/relay/jest.config.js
+++ b/services/relay/jest.config.js
@@ -1,0 +1,1 @@
+export default { transform: {} }

--- a/services/relay/package.json
+++ b/services/relay/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "start": "node src/index.js",
     "test": "node src/test/test.js",
+    "test:jest": "NODE_OPTIONS='--experimental-vm-modules' jest **/*.spec.js",
     "test-autoprune": "node src/test/test-autoprune.js"
   },
   "author": "MRIIOT <ladder99@mriiot.com>",
@@ -23,6 +24,7 @@
     "xml-js": "^1.6.11"
   },
   "devDependencies": {
+    "jest": "^29.7.0",
     "nodemon": "^2.0.14"
   }
 }

--- a/services/relay/src/dataObservations.js
+++ b/services/relay/src/dataObservations.js
@@ -6,7 +6,7 @@ import { Data } from './data.js'
 import * as treeObservations from './treeObservations.js'
 
 // Observations - stores an array of observations - current or sample
-export class Observations extends Data {
+class Observations extends Data {
   //
   constructor(type, agent) {
     super()
@@ -58,11 +58,45 @@ export class Observations extends Data {
   }
 }
 
-// build up an array of history records to write
-// see https://stackoverflow.com/a/63167970/243392
-//. this hardly does anything now
-// just filters down to dataitem's we're interested in, converts value to num/string
-function getHistoryRecords(observations) {
+/**
+ * Build up an array of history records to write
+ *
+ * @remarks This function filters observations down to dataitems we're interested in and converts values to a proper JS datatype.
+ *
+ * @todo The source of of `@param` is annotated with property comments with all seen property values. We might want to improve the property types to allow only selected string values, however that needs to be verified.
+ *
+ * @see {@link https://stackoverflow.com/a/63167970/243392|this SO answer}
+ *
+ * @param {({
+ *          assetType?: string,  // 'UNAVAILABLE'
+ *          category?: string,  // 'CONDITION' | 'EVENT' | 'SAMPLE'
+ *          count?: string,  // `${number}`
+ *          dataItemId: string,  // '*_asset_chg' | '*_asset_count' | '*_asset_rem' | '*_avail' | '*_condition' | '*_pcc' | 'agent_*_asset_chg' | 'agent_*_asset_count' | 'agent_*_asset_rem' | 'agent_avail' | 'device_added' | 'device_changed' | 'device_removed' | 'ox003_sharcs_adapter_software_version' | 'ox003_sharcs_adapter_uri' | 'ox003_sharcs_asset_update_rate' | 'ox003_sharcs_connection_status' | 'ox003_sharcs_mtconnect_version' | 'ox003_sharcs_observation_update_rate'
+ *          dataitem_id?: number,
+ *          device_id?: number,
+ *          name?: string,  // 'availability' | 'partcount'
+ *          sequence: string,  // `${number}`
+ *          statistic?: string,  // 'AVERAGE'
+ *          subType?: string,  // 'COMPLETE'
+ *          tag: string,  // 'AdapterSoftwareVersion' | 'AdapterURI' | 'AssetChanged' | 'AssetCountDataSet' | 'AssetRemoved' | 'AssetUpdateRate' | 'Availability' | 'ConnectionStatus' | 'DeviceAdded' | 'DeviceChanged' | 'DeviceRemoved' | 'MTConnectVersion' | 'Normal' | 'ObservationUpdateRate' | 'PartCount'
+ *          timestamp: string,  // `${Date.toISOString()}`
+ *          type?: string,  // 'SYSTEM'
+ *          uid: string,  // 'Main/*_asset_chg' | 'Main/*_asset_count' | 'Main/*_asset_rem' | 'Main/*_avail' | 'Main/*_condition' | 'Main/*_pcc' | 'Main/agent_*_asset_chg' | 'Main/agent_*_asset_count' | 'Main/agent_*_asset_rem' | 'Main/agent_avail' | 'Main/device_added' | 'Main/device_changed' | 'Main/device_removed' | 'Main/ox003_sharcs_adapter_software_version' | 'Main/ox003_sharcs_adapter_uri' | 'Main/ox003_sharcs_asset_update_rate' | 'Main/ox003_sharcs_connection_status' | 'Main/ox003_sharcs_mtconnect_version' | 'Main/ox003_sharcs_observation_update_rate'
+ *          value?: string  // '00000000-0000-0000-1337-409151d72b38' | 'AVAILABLE' | 'ESTABLISHED' | 'UNAVAILABLE' | 'mqtt://mosquitto:1883'
+ *        })[]} observations - Observations
+ *
+ * @returns {({
+ *          dataitem_id: number,
+ *          node_id: number,
+ *          time: string,
+ *          value: number | string
+ *        })[]}
+ */
+export function getHistoryRecords(observations) {
+  if (!Array.isArray(observations)) {
+    console.warn(`[getHistoryRecords] WARN The following value was set to 'observations', but it is not an array:`, observations)
+    return []
+  }
   const records = []
   for (let obs of observations) {
     if (obs.dataitem_id) {
@@ -81,7 +115,7 @@ function getHistoryRecords(observations) {
         node_id: obs.device_id,
         dataitem_id: obs.dataitem_id,
         time: obs.timestamp,
-        value, // number or string - written as jsonb value
+        value: obs.category === 'CONDITION' ? JSON.stringify(obs.tag) : value, // number or string - written as jsonb value
       }
       records.push(record)
     }

--- a/services/relay/src/dataObservations.js
+++ b/services/relay/src/dataObservations.js
@@ -6,7 +6,7 @@ import { Data } from './data.js'
 import * as treeObservations from './treeObservations.js'
 
 // Observations - stores an array of observations - current or sample
-class Observations extends Data {
+export class Observations extends Data {
   //
   constructor(type, agent) {
     super()
@@ -56,69 +56,70 @@ class Observations extends Data {
     // write all records to db
     return await db.addHistory(records)
   }
+
+  /**
+   * Build up an array of history records to write
+   *
+   * @remarks This method filters observations down to dataitems we're interested in and converts values to a proper JS datatype.
+   *
+   * @todo The source of of `@param` is annotated with property comments with all seen property values. We might want to improve the property types to allow only selected string values, however that needs to be verified.
+   *
+   * @see {@link https://stackoverflow.com/a/63167970/243392|this SO answer}
+   *
+   * @param {({
+   *          assetType?: string,  // 'UNAVAILABLE'
+   *          category?: string,  // 'CONDITION' | 'EVENT' | 'SAMPLE'
+   *          count?: string,  // `${number}`
+   *          dataItemId: string,  // '*_asset_chg' | '*_asset_count' | '*_asset_rem' | '*_avail' | '*_condition' | '*_pcc' | 'agent_*_asset_chg' | 'agent_*_asset_count' | 'agent_*_asset_rem' | 'agent_avail' | 'device_added' | 'device_changed' | 'device_removed' | 'ox003_sharcs_adapter_software_version' | 'ox003_sharcs_adapter_uri' | 'ox003_sharcs_asset_update_rate' | 'ox003_sharcs_connection_status' | 'ox003_sharcs_mtconnect_version' | 'ox003_sharcs_observation_update_rate'
+   *          dataitem_id?: number,
+   *          device_id?: number,
+   *          name?: string,  // 'availability' | 'partcount'
+   *          sequence: string,  // `${number}`
+   *          statistic?: string,  // 'AVERAGE'
+   *          subType?: string,  // 'COMPLETE'
+   *          tag: string,  // 'AdapterSoftwareVersion' | 'AdapterURI' | 'AssetChanged' | 'AssetCountDataSet' | 'AssetRemoved' | 'AssetUpdateRate' | 'Availability' | 'ConnectionStatus' | 'DeviceAdded' | 'DeviceChanged' | 'DeviceRemoved' | 'MTConnectVersion' | 'Normal' | 'ObservationUpdateRate' | 'PartCount'
+   *          timestamp: string,  // `${Date.toISOString()}`
+   *          type?: string,  // 'SYSTEM'
+   *          uid: string,  // 'Main/*_asset_chg' | 'Main/*_asset_count' | 'Main/*_asset_rem' | 'Main/*_avail' | 'Main/*_condition' | 'Main/*_pcc' | 'Main/agent_*_asset_chg' | 'Main/agent_*_asset_count' | 'Main/agent_*_asset_rem' | 'Main/agent_avail' | 'Main/device_added' | 'Main/device_changed' | 'Main/device_removed' | 'Main/ox003_sharcs_adapter_software_version' | 'Main/ox003_sharcs_adapter_uri' | 'Main/ox003_sharcs_asset_update_rate' | 'Main/ox003_sharcs_connection_status' | 'Main/ox003_sharcs_mtconnect_version' | 'Main/ox003_sharcs_observation_update_rate'
+   *          value?: string  // '00000000-0000-0000-1337-409151d72b38' | 'AVAILABLE' | 'ESTABLISHED' | 'UNAVAILABLE' | 'mqtt://mosquitto:1883'
+   *        })[]} observations - Observations
+   *
+   * @returns {({
+   *          dataitem_id: number,
+   *          node_id: number,
+   *          time: string,
+   *          value: number | string
+   *        })[]}
+   */
+  getHistoryRecords(observations) {
+    if (!Array.isArray(observations)) {
+      console.warn(`[getHistoryRecords] WARN The following value was set to 'observations', but it is not an array:`, observations)
+      return []
+    }
+    const records = []
+    for (let obs of observations) {
+      if (obs.dataitem_id) {
+        // obs.value is always string, due to the way the xml is stored, like <value>10</value>
+        // use dataitem category to convert to number
+        // ie SAMPLES are numeric, EVENTS are strings
+        //. convert 'UNAVAILABLE' samples to null?
+        //. keep in mind that conditions can have >1 value also
+        // const value = Number(obs.value) || JSON.stringify(obs.value) // bug: this converted 0's to "0" - should have used ?? operator
+        // try to convert to number - if not, convert to a json string, eg 'AVAILABLE' -> '"AVAILABLE"'
+        const nval = Number(obs.value) // try convert to number //. what if value is 'UNAVAILABLE' or null? then get NaN or 0 (!)
+        // const value = Number.isNaN(nval) ? JSON.stringify(obs.value) : nval
+        const useNumber = obs.category === 'SAMPLE' && !Number.isNaN(nval)
+        const value = useNumber ? nval : JSON.stringify(obs.value)
+        const record = {
+          node_id: obs.device_id,
+          dataitem_id: obs.dataitem_id,
+          time: obs.timestamp,
+          value: obs.category === 'CONDITION' ? JSON.stringify(obs.tag) : value, // number or string - written as jsonb value
+        }
+        records.push(record)
+      }
+    }
+    return records
+  }
 }
 
-/**
- * Build up an array of history records to write
- *
- * @remarks This function filters observations down to dataitems we're interested in and converts values to a proper JS datatype.
- *
- * @todo The source of of `@param` is annotated with property comments with all seen property values. We might want to improve the property types to allow only selected string values, however that needs to be verified.
- *
- * @see {@link https://stackoverflow.com/a/63167970/243392|this SO answer}
- *
- * @param {({
- *          assetType?: string,  // 'UNAVAILABLE'
- *          category?: string,  // 'CONDITION' | 'EVENT' | 'SAMPLE'
- *          count?: string,  // `${number}`
- *          dataItemId: string,  // '*_asset_chg' | '*_asset_count' | '*_asset_rem' | '*_avail' | '*_condition' | '*_pcc' | 'agent_*_asset_chg' | 'agent_*_asset_count' | 'agent_*_asset_rem' | 'agent_avail' | 'device_added' | 'device_changed' | 'device_removed' | 'ox003_sharcs_adapter_software_version' | 'ox003_sharcs_adapter_uri' | 'ox003_sharcs_asset_update_rate' | 'ox003_sharcs_connection_status' | 'ox003_sharcs_mtconnect_version' | 'ox003_sharcs_observation_update_rate'
- *          dataitem_id?: number,
- *          device_id?: number,
- *          name?: string,  // 'availability' | 'partcount'
- *          sequence: string,  // `${number}`
- *          statistic?: string,  // 'AVERAGE'
- *          subType?: string,  // 'COMPLETE'
- *          tag: string,  // 'AdapterSoftwareVersion' | 'AdapterURI' | 'AssetChanged' | 'AssetCountDataSet' | 'AssetRemoved' | 'AssetUpdateRate' | 'Availability' | 'ConnectionStatus' | 'DeviceAdded' | 'DeviceChanged' | 'DeviceRemoved' | 'MTConnectVersion' | 'Normal' | 'ObservationUpdateRate' | 'PartCount'
- *          timestamp: string,  // `${Date.toISOString()}`
- *          type?: string,  // 'SYSTEM'
- *          uid: string,  // 'Main/*_asset_chg' | 'Main/*_asset_count' | 'Main/*_asset_rem' | 'Main/*_avail' | 'Main/*_condition' | 'Main/*_pcc' | 'Main/agent_*_asset_chg' | 'Main/agent_*_asset_count' | 'Main/agent_*_asset_rem' | 'Main/agent_avail' | 'Main/device_added' | 'Main/device_changed' | 'Main/device_removed' | 'Main/ox003_sharcs_adapter_software_version' | 'Main/ox003_sharcs_adapter_uri' | 'Main/ox003_sharcs_asset_update_rate' | 'Main/ox003_sharcs_connection_status' | 'Main/ox003_sharcs_mtconnect_version' | 'Main/ox003_sharcs_observation_update_rate'
- *          value?: string  // '00000000-0000-0000-1337-409151d72b38' | 'AVAILABLE' | 'ESTABLISHED' | 'UNAVAILABLE' | 'mqtt://mosquitto:1883'
- *        })[]} observations - Observations
- *
- * @returns {({
- *          dataitem_id: number,
- *          node_id: number,
- *          time: string,
- *          value: number | string
- *        })[]}
- */
-export function getHistoryRecords(observations) {
-  if (!Array.isArray(observations)) {
-    console.warn(`[getHistoryRecords] WARN The following value was set to 'observations', but it is not an array:`, observations)
-    return []
-  }
-  const records = []
-  for (let obs of observations) {
-    if (obs.dataitem_id) {
-      // obs.value is always string, due to the way the xml is stored, like <value>10</value>
-      // use dataitem category to convert to number
-      // ie SAMPLES are numeric, EVENTS are strings
-      //. convert 'UNAVAILABLE' samples to null?
-      //. keep in mind that conditions can have >1 value also
-      // const value = Number(obs.value) || JSON.stringify(obs.value) // bug: this converted 0's to "0" - should have used ?? operator
-      // try to convert to number - if not, convert to a json string, eg 'AVAILABLE' -> '"AVAILABLE"'
-      const nval = Number(obs.value) // try convert to number //. what if value is 'UNAVAILABLE' or null? then get NaN or 0 (!)
-      // const value = Number.isNaN(nval) ? JSON.stringify(obs.value) : nval
-      const useNumber = obs.category === 'SAMPLE' && !Number.isNaN(nval)
-      const value = useNumber ? nval : JSON.stringify(obs.value)
-      const record = {
-        node_id: obs.device_id,
-        dataitem_id: obs.dataitem_id,
-        time: obs.timestamp,
-        value: obs.category === 'CONDITION' ? JSON.stringify(obs.tag) : value, // number or string - written as jsonb value
-      }
-      records.push(record)
-    }
-  }
-  return records
-}

--- a/services/relay/src/dataObservations.spec.js
+++ b/services/relay/src/dataObservations.spec.js
@@ -1,0 +1,109 @@
+import { jest } from '@jest/globals'
+
+import { getHistoryRecords } from './dataObservations'
+
+describe('dataObservations', () => {
+  describe('getHistoryRecords()', () => {
+    describe('general tests', () => {
+      it('should return an empty array when no observation has `dataitem_id` property', () => {
+        expect(getHistoryRecords([{
+          category: 'CONDITION',
+          dataItemId: '48e7290b1184_condition',
+          device_id: 751,
+          sequence: '51',
+          tag: 'Normal',
+          timestamp: '2024-02-25T03:13:36.67177Z',
+          type: 'SYSTEM',
+          uid: 'Main/48e7290b1184_condition'
+        }])).toStrictEqual([])
+      })
+
+      it('should return an empty array when no observation has `dataitem_id` property', () => {
+        const warn = jest.spyOn(console, 'warn').mockImplementation((m) => {})
+        const observations = {
+          category: 'CONDITION',
+          dataItemId: '48e7290b1184_condition',
+          dataitem_id: 774,
+          device_id: 751,
+          sequence: '51',
+          tag: 'Normal',
+          timestamp: '2024-02-25T03:13:36.67177Z',
+          type: 'SYSTEM',
+          uid: 'Main/48e7290b1184_condition'
+        }
+
+        getHistoryRecords(observations)
+
+        expect(warn).toHaveBeenCalledWith(`[getHistoryRecords] WARN The following value was set to 'observations', but it is not an array:`, observations)
+      })
+    })
+
+    describe('test `value` type conversion', () => {
+      it('should be converted to number when `category` is `SAMPLE` and `value` is a number stored as a string', () => {
+        expect(getHistoryRecords([{
+          category: 'SAMPLE',
+          dataItemId: '409151d72b38_pcc',
+          dataitem_id: 771,
+          device_id: 769,
+          name: 'partcount',
+          sequence: '31',
+          subType: 'COMPLETE',
+          tag: 'PartCount',
+          timestamp: '2024-02-25T03:05:44.384587Z',
+          uid: 'Main/409151d72b38_pcc',
+          value: '111'
+        }])).toStrictEqual([
+          {
+            dataitem_id: 771,
+            node_id: 769,
+            time: '2024-02-25T03:05:44.384587Z',
+            value: 111
+          }
+        ])
+      })
+
+      it('should be converted to JSON string', () => {
+        expect(getHistoryRecords([{
+          dataItemId: 'ox003_sharcs_adapter_uri',
+          dataitem_id: 743,
+          device_id: 111,
+          sequence: '9',
+          tag: 'AdapterURI',
+          timestamp: '2024-02-25T03:05:44.384387Z',
+          uid: 'Main/ox003_sharcs_adapter_uri',
+          value: 'mqtt://mosquitto:1883'
+        }])).toStrictEqual([
+          {
+            dataitem_id: 743,
+            node_id: 111,
+            time: '2024-02-25T03:05:44.384387Z',
+            value: '"mqtt://mosquitto:1883"'
+          }
+        ])
+      })
+    })
+
+    describe('test the value for `CONDITION` category', () => {
+      it('should be set to the `tag` value', () => {
+        expect(getHistoryRecords([{
+          category: 'CONDITION',
+          dataItemId: '48e7290b1184_condition',
+          dataitem_id: 1201,
+          device_id: 751,
+          sequence: '51',
+          tag: 'Normal',
+          timestamp: '2024-02-25T03:13:36.67177Z',
+          type: 'SYSTEM',
+          uid: 'Main/48e7290b1184_condition'
+        }])).toStrictEqual([
+          {
+            dataitem_id: 1201,
+            node_id: 751,
+            time: '2024-02-25T03:13:36.67177Z',
+            value: '"Normal"'
+          }
+        ])
+      })
+    })
+  })
+})

--- a/services/relay/src/dataObservations.spec.js
+++ b/services/relay/src/dataObservations.spec.js
@@ -1,12 +1,18 @@
 import { jest } from '@jest/globals'
 
-import { getHistoryRecords } from './dataObservations'
+import { Observations } from './dataObservations'
 
 describe('dataObservations', () => {
+  let observations
+
+  beforeAll(() => {
+    observations = new Observations()
+  })
+
   describe('getHistoryRecords()', () => {
     describe('general tests', () => {
       it('should return an empty array when no observation has `dataitem_id` property', () => {
-        expect(getHistoryRecords([{
+        expect(observations.getHistoryRecords([{
           category: 'CONDITION',
           dataItemId: '48e7290b1184_condition',
           device_id: 751,
@@ -20,7 +26,7 @@ describe('dataObservations', () => {
 
       it('should return an empty array when no observation has `dataitem_id` property', () => {
         const warn = jest.spyOn(console, 'warn').mockImplementation((m) => {})
-        const observations = {
+        const obs = {
           category: 'CONDITION',
           dataItemId: '48e7290b1184_condition',
           dataitem_id: 774,
@@ -32,15 +38,15 @@ describe('dataObservations', () => {
           uid: 'Main/48e7290b1184_condition'
         }
 
-        getHistoryRecords(observations)
+        observations.getHistoryRecords(obs)
 
-        expect(warn).toHaveBeenCalledWith(`[getHistoryRecords] WARN The following value was set to 'observations', but it is not an array:`, observations)
+        expect(warn).toHaveBeenCalledWith(`[getHistoryRecords] WARN The following value was set to 'observations', but it is not an array:`, obs)
       })
     })
 
     describe('test `value` type conversion', () => {
       it('should be converted to number when `category` is `SAMPLE` and `value` is a number stored as a string', () => {
-        expect(getHistoryRecords([{
+        expect(observations.getHistoryRecords([{
           category: 'SAMPLE',
           dataItemId: '409151d72b38_pcc',
           dataitem_id: 771,
@@ -63,7 +69,7 @@ describe('dataObservations', () => {
       })
 
       it('should be converted to JSON string', () => {
-        expect(getHistoryRecords([{
+        expect(observations.getHistoryRecords([{
           dataItemId: 'ox003_sharcs_adapter_uri',
           dataitem_id: 743,
           device_id: 111,
@@ -85,7 +91,7 @@ describe('dataObservations', () => {
 
     describe('test the value for `CONDITION` category', () => {
       it('should be set to the `tag` value', () => {
-        expect(getHistoryRecords([{
+        expect(observations.getHistoryRecords([{
           category: 'CONDITION',
           dataItemId: '48e7290b1184_condition',
           dataitem_id: 1201,


### PR DESCRIPTION
I update `getHistoryRecords()` function so that it returns MTConnect XML condition tag name as a value which is persisted into database.

At the same time, I have install Jest and created some tests for this function. For this, I have added an NPM script (into `package.json` which can be run as `npm run test:jest` (`npm run test` is running some e2e tests, so I had to choose a different name) after changing to `services/relay` folder and installing the NPM dependencies (`npm i`).