### PR TITLE
chore: remove Docker image output type specification

### DIFF
--- a/build
+++ b/build
@@ -65,6 +65,5 @@ docker buildx inspect --bootstrap
 docker buildx build \
   --platform "$(IFS=,; echo "${platforms[*]}")" \
   --push \
-  --output type=docker \
   -t "$USERNAME/$SERVICE:$VERSION" \
   "$repo_root/services/$SERVICE"


### PR DESCRIPTION
It was required when we built separate images for each platform and then combined them into a multi-arch image.

Now, we create the multi-arch image in a single step which does not support `--output type=docker`, however, it is not required anymore for our use case.